### PR TITLE
Changed 3 to 3T in respective profiles

### DIFF
--- a/system/etc/AKT/BEFT
+++ b/system/etc/AKT/BEFT
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-#Interactive Governor tweaks for OnePlus 3.
+#Interactive Governor tweaks for OnePlus 3T.
 #Stock are the stock settings from ElementalX kernel
 #Scripts made by Senthil360 and Asiier and changed by Mostafa Wael
 #Credits for @Asiier/@Mostafa Wael/@Senthil360

--- a/system/etc/AKT/FairParkT
+++ b/system/etc/AKT/FairParkT
@@ -1,7 +1,7 @@
 #!/system/bin/sh
 #Author: Asiier
 #Settings By: Asiier
-#Device: One Plus 3
+#Device: One Plus 3T
 #Codename: FairParkHE
 #Build Status: Stable
 #Version: 2.5

--- a/system/etc/AKT/FusionCT
+++ b/system/etc/AKT/FusionCT
@@ -1,5 +1,5 @@
 #!/system/bin/sh
-#Interactive Governor tweaks for OnePlus 3.
+#Interactive Governor tweaks for OnePlus 3T.
 #Fusion Conservative 
 #Conservative profile to save battery 
 #Scripts made by Senthil360 and Asiier and changed by patalao

--- a/system/etc/AKT/FusionPT
+++ b/system/etc/AKT/FusionPT
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 #This script is licensed under GPLV2
-#Interactive Governor tweaks for OnePlus 3.
+#Interactive Governor tweaks for OnePlus 3T.
 #Fusion profiles are set for a balanced and performance use.
 #FusionB, FusionP and Stock settings are present in this script.
 #FusionB is tweaked in a way that Cluster 1 (small) uses mostly the frequencies from 307 to 1324 and when needed, Cluster 2(big) enters to help, using frequencies up to 1632 and jumping above that when extreme load is present.

--- a/system/etc/AKT/GhostPepperT
+++ b/system/etc/AKT/GhostPepperT
@@ -1,7 +1,7 @@
 #!/system/bin/sh
 #Author: Asiier
 #Settings By: Asiier
-#Device: One Plus 3
+#Device: One Plus 3T
 #Codename: GhostPepper
 #Build Status: Stable
 #Version: 2.0

--- a/system/etc/AKT/HawkPepperT
+++ b/system/etc/AKT/HawkPepperT
@@ -1,7 +1,7 @@
 #!/system/bin/sh
 #Author: Asiier
 #Settings By: Asiier
-#Device: One Plus 3
+#Device: One Plus 3T
 #Codename: HawkPepper
 #Build Status: Stable
 #Version: 2.0

--- a/system/etc/AKT/NLB_balancedT
+++ b/system/etc/AKT/NLB_balancedT
@@ -1,8 +1,8 @@
 #!/system/bin/sh
 #NAMELESS_PROFILE_V5_23rd_November
-#"Nameless" Tweaks for OP3 by @Senthil360
+#"Nameless" Tweaks for OP3T by @Senthil360
 #Thanks to @Asiier ,  @patalao and @Mostafa Wael
-#This profile works in a way which takes advantage of the HMP system of SD 820,
+#This profile works in a way which takes advantage of the HMP system of SD 821,
 #LITTLE cluster frequency are kept at low to medium levels 
 # BIG Cluster comes into play when load is around 90 to help out LITTLE and ease the load 
 #So eventually after load is reduced  both clusters idle soon,  thus saving a lot of Battery

--- a/system/etc/AKT/NLB_batteryT
+++ b/system/etc/AKT/NLB_batteryT
@@ -1,8 +1,8 @@
 #!/system/bin/sh
 #NAMELESS_PROFILE_V5_23rd_November
-#"Nameless" Tweaks for OP3 by @Senthil360
+#"Nameless" Tweaks for OP3T by @Senthil360
 #Thanks to @Asiier ,  @patalao and @Mostafa Wael
-#This profile works in a way which takes advantage of the HMP system of SD 820,
+#This profile works in a way which takes advantage of the HMP system of SD 821,
 #LITTLE cluster frequency are kept at low to medium levels 
 # BIG Cluster comes into play when load is around 90 to help out LITTLE and ease the load 
 #So eventually after load is reduced  both clusters idle soon,  thus saving a lot of Battery

--- a/system/etc/AKT/NLB_performanceT
+++ b/system/etc/AKT/NLB_performanceT
@@ -1,8 +1,8 @@
 #!/system/bin/sh
 #NAMELESS_PROFILE_V5_23rd_November
-#"Nameless" Tweaks for OP3 by @Senthil360
+#"Nameless" Tweaks for OP3T by @Senthil360
 #Thanks to @Asiier ,  @patalao and @Mostafa Wael
-#This profile works in a way which takes advantage of the HMP system of SD 820,
+#This profile works in a way which takes advantage of the HMP system of SD 821,
 #LITTLE cluster frequency are kept at low to medium levels 
 # BIG Cluster comes into play when load is around 90 to help out LITTLE and ease the load 
 #So eventually after load is reduced  both clusters idle soon,  thus saving a lot of Battery

--- a/system/etc/AKT/PX_balancedT
+++ b/system/etc/AKT/PX_balancedT
@@ -1,7 +1,7 @@
 #!/system/bin/sh
 #Author: Asiier
 #Settings By: Asiier
-#Device: One Plus 3
+#Device: One Plus 3T
 #Codename: Project X.A.N.A (B)
 #Build Status: Stable
 #Version: 4.2

--- a/system/etc/AKT/PX_batteryT
+++ b/system/etc/AKT/PX_batteryT
@@ -1,7 +1,7 @@
 #!/system/bin/sh
 #Author: Asiier
 #Settings By: Asiier
-#Device: One Plus 3
+#Device: One Plus 3T
 #Codename: Project X.A.N.A (BT)
 #Build Status: Stable
 #Version: 4.2

--- a/system/etc/AKT/PX_battery_extremeT
+++ b/system/etc/AKT/PX_battery_extremeT
@@ -1,7 +1,7 @@
 #!/system/bin/sh
 #Author: Asiier
 #Settings By: Asiier
-#Device: One Plus 3
+#Device: One Plus 3T
 #Codename: Project X.A.N.A (BE)
 #Build Status: Stable
 #Last Updated: 22/01/2017

--- a/system/etc/AKT/PZ_balancedT
+++ b/system/etc/AKT/PZ_balancedT
@@ -1,7 +1,7 @@
 #!/system/bin/sh
 #Author: Asiier
 #Settings By: Asiier
-#Device: One Plus 3
+#Device: One Plus 3T
 #Codename: Project Zhana (B)
 #Build Status: Stable
 #Version: 4.2

--- a/system/etc/AKT/PZ_batteryT
+++ b/system/etc/AKT/PZ_batteryT
@@ -1,7 +1,7 @@
 #!/system/bin/sh
 #Author: Asiier
 #Settings By: Asiier
-#Device: One Plus 3
+#Device: One Plus 3T
 #Codename: Project Zhana (BT)
 #Build Status: Stable
 #Version: 4.2


### PR DESCRIPTION
I noticed that the profiles for 3T also had 'One Plus 3' written in their config files, so I changed them to 'One Plus 3T' to avoid confusion. 